### PR TITLE
Using baseTest as a listener -instead of extending it

### DIFF
--- a/TestNG/webTestng.xml
+++ b/TestNG/webTestng.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
-<suite name="Web Automation Tests" preserve-order="true" configfailurepolicy="continue" parallel="methods" thread-count="4">
+<suite name="Web Automation Tests" preserve-order="true" configfailurepolicy="continue" parallel="methods" thread-count="1">
     <test name="LoginTests" preserve-order="true">
         <classes>
             <class name="com.znsio.rpap.WebExampleTest"/>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,10 @@
                     <properties>
                         <property>
                             <name>listener</name>
-                            <value>com.znsio.reportportal.integration.listener.ReportPortalListener</value>
+                            <value>
+                                com.znsio.reportportal.integration.listener.ReportPortalListener,
+                                com.znsio.rpap.BaseTest
+                            </value>
                         </property>
                     </properties>
                 </configuration>

--- a/src/test/java/com/znsio/rpap/WebExampleTest.java
+++ b/src/test/java/com/znsio/rpap/WebExampleTest.java
@@ -4,26 +4,40 @@ import com.znsio.rpap.businessLayer.WebBL;
 import com.znsio.rpap.pages.WebExample;
 import com.znsio.rpap.utils.JsonDataManager;
 import com.znsio.rpap.utils.JsonDataProvider;
+import org.openqa.selenium.WebDriver;
+import org.testng.ISuite;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.testng.xml.XmlTest;
 
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.MalformedURLException;
 
 import static com.znsio.reportportal.integration.utils.ReportPortalLogger.logInfoMessage;
 
 
 //TODO: Consume BaseTest as a listener instead of an inherited class
-public class WebExampleTest extends BaseTest {
+public class WebExampleTest {
     private WebExample webPage;
     private WebBL webBL;
+    private BaseTest bt;
+
+
+    @BeforeSuite
+    public void getBaseTest(XmlTest suite) throws IOException {
+        bt = new BaseTest();
+        bt.suiteSetup(suite);
+    }
 
     @BeforeMethod
-    public void webPageSetup() {
-
+    public void webPageSetup(Method method) throws MalformedURLException {
+        bt.methodSetup(method);
         logInfoMessage("Inside @BeforeMethod of " + WebExampleTest.class.getSimpleName());
-        webPage = page.getClassInstance(WebExample.class);
-        webBL = new WebBL(driver, webPage, applitoolsInitializer.getWebEyes());
+        webPage = bt.page.getClassInstance(WebExample.class);
+        webBL = new WebBL(bt.driver, webPage, bt.applitoolsInitializer.getWebEyes());
     }
 
     @Test(dataProvider = "getFromJson", priority = -1, description = "Validate Title of the Screen", groups = {"visual"})

--- a/src/test/java/com/znsio/rpap/WebExampleTest.java
+++ b/src/test/java/com/znsio/rpap/WebExampleTest.java
@@ -18,8 +18,6 @@ import java.net.MalformedURLException;
 
 import static com.znsio.reportportal.integration.utils.ReportPortalLogger.logInfoMessage;
 
-
-//TODO: Consume BaseTest as a listener instead of an inherited class
 public class WebExampleTest {
     private WebExample webPage;
     private WebBL webBL;


### PR DESCRIPTION
Using the BaseTest as a listener, instead of extending it in the test class

Implemeted these changes in WebExampleTest

this branch is forked from para_merge - so creating the PR for para_merge branch instead of main



**Pending task**
Need to implement these changes in AppExampleTest also
Capability to provide custom configs for UFG from consumer framework
